### PR TITLE
Add focal loss option for classification

### DIFF
--- a/spanet/options.py
+++ b/spanet/options.py
@@ -235,6 +235,9 @@ class Options(Namespace):
         # Scalar term for classification Cross Entropy loss term
         self.classification_loss_scale: float = 0.0
 
+        # Gamma exponent for classification focal loss. Setting it to 0.0 will disable focal loss and use regular cross-entropy.
+        self.classification_focal_gamma: float = 0.0
+
         # Automatically balance loss terms using Jacobians.
         self.balance_losses: bool = True
 


### PR DESCRIPTION
- Add focal loss option for classification

Note I explicitly keep the current implementation `F.cross_entropy` if `self.options.classification_focal_gamma == 0` out of an abundance of caution even though I checked that, numerically, the more complex formula gives the same answer.

The difference is that `F.cross_entropy` fuses `F.log_softmax` and `F.nll_loss`, so it is supposed to be more numerically stable, which I wanted to keep. But if you think it's unnecessary, we can remove this if-then clause.

@mstamenk