### PR TITLE
Include rich as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'sympy',
         'pyyaml',
         'opt_einsum',
-        'scikit-learn'
+        'scikit-learn',
+        'rich'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
A missing dependency is included in `setup.py`, to install the `rich` package.

This is needed for example at https://github.com/Alexanders101/SPANet/blob/8bd33bd3ac4893944b1f0e7e4cad556489f36a75/spanet/evaluation.py#L8 where there is an `from rich import progress`, but it is not included yet as a required package in `setup.py`.