### PR TITLE
fixed assert

### DIFF
--- a/spanet/dataset/evaluator.py
+++ b/spanet/dataset/evaluator.py
@@ -29,9 +29,8 @@ class SymmetricEvaluator:
             cluster_group = self.target_groups[names[0]]
             for name in names:
                 assert (
-                    self.target_groups[name] == cluster_group,
-                    "Invalid Symmetry Group. Invariant targets have different structures."
-                )
+                    self.target_groups[name] == cluster_group
+                ), "Invalid Symmetry Group. Invariant targets have different structures."
 
             cluster_groups.append((cluster_name, names, cluster_group))
 


### PR DESCRIPTION
The parentheses made this a non-empty tuple which always evaluates to True:

```
spanet/dataset/evaluator.py:31: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert (
```